### PR TITLE
Complex Disjunction with more than 2 items

### DIFF
--- a/src/FluentMongo.Tests/Linq/MongoQueryTests.cs
+++ b/src/FluentMongo.Tests/Linq/MongoQueryTests.cs
@@ -491,6 +491,14 @@ namespace FluentMongo.Linq
             Assert.AreEqual(3, people.Count);
         }
 
+		[Test]
+		public void Complex_Disjunction_MoreThan2()
+		{
+			var people = Collection.AsQueryable().Where(x => x.Age == 21 || x.Age == 35 || x.Age == 42).ToList();
+
+			Assert.AreEqual(3, people.Count);
+		}
+
         public Action<string> log { get; set; }
     }
 }


### PR DESCRIPTION
I have run into a bug where I can not query on more than 2 items in the where clause.  I am not as familiar with Linq as I'd like to be, so I haven't been able to track down the problem or come up with a solution.

I added a failing test to show the problem.

Cheers
