### PR TITLE
Enable !field in the provider

### DIFF
--- a/src/FluentMongo.Tests/Linq/MongoQueryProviderTests.cs
+++ b/src/FluentMongo.Tests/Linq/MongoQueryProviderTests.cs
@@ -24,7 +24,7 @@ namespace FluentMongo.Linq
             var people = Collection.AsQueryable().Where(x => !x.PrimaryAddress.IsInternational);
 
             var queryObject = ((IMongoQueryable)people).GetQueryObject();
-            Assert.AreEqual(new BsonDocument("$not", new BsonDocument("add.IsInternational", true)), queryObject.Query);
+            Assert.AreEqual(new BsonDocument("add.IsInternational", false), queryObject.Query);
         }
 
         [Test]

--- a/src/FluentMongo.Tests/Linq/MongoQueryTests.cs
+++ b/src/FluentMongo.Tests/Linq/MongoQueryTests.cs
@@ -102,12 +102,11 @@ namespace FluentMongo.Linq
         }
 
         [Test]
-        [Ignore("Mongodb does not support this type of query.")]
         public void Boolean_Inverse()
         {
             var people = Enumerable.ToList(Collection.AsQueryable().Where(x => !x.PrimaryAddress.IsInternational));
 
-            Assert.AreEqual(1, people.Count);
+            Assert.AreEqual(2, people.Count);
         }
 
         [Test]

--- a/src/FluentMongo/Linq/Translators/BsonDocumentFormatter.cs
+++ b/src/FluentMongo/Linq/Translators/BsonDocumentFormatter.cs
@@ -261,9 +261,18 @@ namespace FluentMongo.Linq.Translators
             switch (u.NodeType)
             {
                 case ExpressionType.Not:
-                    PushConditionScope("$not");
-                    VisitPredicate(u.Operand, false);
-                    PopConditionScope();
+                    if (u.Operand is FieldExpression)
+                    {
+                        VisitPredicate(u.Operand, true);
+                        AddCondition(false);
+                        PopConditionScope();
+                    }
+                    else
+                    {
+                        PushConditionScope("$not");
+                        VisitPredicate(u.Operand, false);
+                        PopConditionScope();
+                    }
                     break;
                 case ExpressionType.ArrayLength:
                     Visit(u.Operand);


### PR DESCRIPTION
If a NotExpression is used on a field, this field will be tested as equal to false.
