### PR TITLE
Add support for de-selecting _id field with Select()

### DIFF
--- a/src/FluentMongo.Tests/Linq/Entities.cs
+++ b/src/FluentMongo.Tests/Linq/Entities.cs
@@ -69,4 +69,9 @@ namespace FluentMongo.Linq
     {
         public double Salary { get; set; }
     }
+
+    public class NoIdEntity
+    {
+        public string Name { get; set; }
+    }
 }

--- a/src/FluentMongo.Tests/Linq/MongoQueryProviderTests.cs
+++ b/src/FluentMongo.Tests/Linq/MongoQueryProviderTests.cs
@@ -47,7 +47,7 @@ namespace FluentMongo.Linq
                 .Select(x => x.Name);
 
             var queryObject = ((IMongoQueryable)people).GetQueryObject();
-            Assert.AreEqual(2, queryObject.Fields.ElementCount);
+            Assert.AreEqual(3, queryObject.Fields.ElementCount);
             Assert.AreEqual(0, queryObject.NumberToLimit);
             Assert.AreEqual(0, queryObject.NumberToSkip);
             Assert.AreEqual(new BsonDocument("age", new BsonDocument("$gt", 21)), queryObject.Query);
@@ -62,7 +62,7 @@ namespace FluentMongo.Linq
                 .Select(x => x.Name);
 
             var queryObject = ((IMongoQueryable)people).GetQueryObject();
-            Assert.AreEqual(2, queryObject.Fields.ElementCount);
+            Assert.AreEqual(3, queryObject.Fields.ElementCount);
             Assert.AreEqual(0, queryObject.NumberToLimit);
             Assert.AreEqual(0, queryObject.NumberToSkip);
             Assert.AreEqual(new BsonDocument("$where", @"((this.fn + this.ln) === ""BobMcBob"")"), queryObject.Query);
@@ -148,7 +148,7 @@ namespace FluentMongo.Linq
                          select (string)p["fn"];
 
             var queryObject = ((IMongoQueryable)people).GetQueryObject();
-            Assert.AreEqual(new BsonDocument { { "fn", 1 } }, queryObject.Fields);
+            Assert.AreEqual(new BsonDocument { { "fn", 1 }, { "_id", 0 } }, queryObject.Fields);
             Assert.AreEqual(0, queryObject.NumberToLimit);
             Assert.AreEqual(0, queryObject.NumberToSkip);
             Assert.AreEqual(
@@ -409,7 +409,8 @@ namespace FluentMongo.Linq
             Assert.AreEqual(
                 new BsonDocument(
                     new BsonElement("fn", 1),
-                    new BsonElement("ln", 1)),
+                    new BsonElement("ln", 1),
+                    new BsonElement("_id", 0)),
                 queryObject.Fields);
         }
 
@@ -426,7 +427,8 @@ namespace FluentMongo.Linq
             Assert.AreEqual(
                 new BsonDocument(
                     new BsonElement("fn", 1),
-                    new BsonElement("ln", 1)),
+                    new BsonElement("ln", 1),
+                    new BsonElement("_id", 0)),
                 queryObject.Fields);
 
             Assert.AreEqual(
@@ -585,6 +587,20 @@ namespace FluentMongo.Linq
             var queryObject = ((IMongoQueryable)people).GetQueryObject();
 
             Assert.AreEqual(new BsonDocument("_t", typeof(Employee).Name), queryObject.Query);
+        }
+
+        [Test]
+        public void ProjectionWithoutIdShouldUnselectItExplicitly()
+        {
+            var noId = GetCollection<NoIdEntity>("no_id").AsQueryable().Select(n => n.Name);
+
+            var queryObject = ((IMongoQueryable)noId).GetQueryObject();
+
+            Assert.AreEqual(
+                new BsonDocument(
+                    new BsonElement("Name", 1),
+                    new BsonElement("_id", 0)),
+                queryObject.Fields);
         }
     }
 }

--- a/src/FluentMongo.Tests/Linq/MongoQueryTests.cs
+++ b/src/FluentMongo.Tests/Linq/MongoQueryTests.cs
@@ -12,6 +12,7 @@ namespace FluentMongo.Linq
     public class MongoQueryTests : LinqTestBase
     {
         private readonly Guid _searchableGuid = Guid.NewGuid();
+        private MongoCollection<NoIdEntity> NoIdCollection;
 
         public override void SetupFixture()
         {
@@ -83,6 +84,10 @@ namespace FluentMongo.Linq
                     EmployerIds = new int[0],
                 },
                 SafeMode.True);
+
+            NoIdCollection = GetCollection<NoIdEntity>("no_id");
+
+            NoIdCollection.Insert(new NoIdEntity { Name = "Bob" });
         }
 
         [Test]
@@ -542,6 +547,14 @@ namespace FluentMongo.Linq
             var people = Collection.AsQueryable().ToList();
 
             Assert.AreEqual(4, people.Count);
+        }
+
+        [Test]
+        public void UseSelectorInEntityWithoutId()
+        {
+            var noIdName = NoIdCollection.AsQueryable().Select(n => n.Name).First();
+
+            Assert.AreEqual("Bob", noIdName);
         }
     }
 }

--- a/src/FluentMongo/Linq/Expressions/MongoExpressionExtensions.cs
+++ b/src/FluentMongo/Linq/Expressions/MongoExpressionExtensions.cs
@@ -8,7 +8,7 @@ namespace FluentMongo.Linq.Expressions
     {
         public static bool HasSelectAllField(this IEnumerable<FieldDeclaration> fields)
         {
-            return fields == null || fields.Any(f => f.Name == "*");
+            return fields == null || fields.Count() == 0 || fields.Any(f => f.Name == "*");
         }
 
         public static SelectExpression AddField(this SelectExpression select, FieldDeclaration field)

--- a/src/FluentMongo/Linq/Translators/MongoQueryObjectBuilder.cs
+++ b/src/FluentMongo/Linq/Translators/MongoQueryObjectBuilder.cs
@@ -54,6 +54,10 @@ namespace FluentMongo.Linq.Translators
                     foreach (var expandedField in expandedFields)
                         _queryObject.Fields[expandedField.Name] = 1;
                 }
+
+                // if the _id field isn't selected, then unselect it explicitly
+                if (!_queryObject.Fields.Contains("_id"))
+                    _queryObject.Fields.Add("_id", 0);
             }
 
             if (select.OrderBy != null)


### PR DESCRIPTION
When using a projection that doesn't select the Id field and the destination class doesn't contains an Id field, fluent-mongo will fail to deserialize it.
When selecting fields in mongodb, _id is always included in the results unless you specifically unselect it with { '_id' : 0 }.
