### PR TITLE
Fix exception when selecting sub-id elements but not the Id itself in a Select clause.

### DIFF
--- a/src/FluentMongo.Tests/Linq/Entities.cs
+++ b/src/FluentMongo.Tests/Linq/Entities.cs
@@ -90,4 +90,15 @@ namespace FluentMongo.Linq
     {
         public string Name { get; set; }
     }
+
+    public class CustomId
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+
+    public class CustomIdEntity
+    {
+        public CustomId Id { get; set; }
+    }
 }

--- a/src/FluentMongo.Tests/Linq/MongoQueryProviderTests.cs
+++ b/src/FluentMongo.Tests/Linq/MongoQueryProviderTests.cs
@@ -639,5 +639,29 @@ namespace FluentMongo.Linq
                     new BsonElement("_id", 0)),
                 queryObject.Fields);
         }
+
+        [Test]
+        public void QueryWithCustomIdEntity()
+        {
+            var customId = GetCollection<CustomIdEntity>("custom_id").AsQueryable().Where(c => c.Id.FirstName == "firstname");
+            var queryObject = ((IMongoQueryable)customId).GetQueryObject();
+
+            Assert.AreEqual(
+                new BsonDocument(new BsonElement("_id.FirstName", "firstname")),
+                queryObject.Query);
+        }
+
+        [Test]
+        public void SelectSubIdFieldsWithCustomIdEntity()
+        {
+            var customId = GetCollection<CustomIdEntity>("custom_id").AsQueryable().Select(c => new { c.Id.FirstName, c.Id.LastName });
+            var queryObject = ((IMongoQueryable)customId).GetQueryObject();
+
+            Assert.AreEqual(
+                new BsonDocument(
+                    new BsonElement("_id.FirstName", 1),
+                    new BsonElement("_id.LastName", 1)),
+                queryObject.Fields);
+        }
     }
 }

--- a/src/FluentMongo.Tests/Linq/MongoQueryTests.cs
+++ b/src/FluentMongo.Tests/Linq/MongoQueryTests.cs
@@ -13,6 +13,7 @@ namespace FluentMongo.Linq
     {
         private readonly Guid _searchableGuid = Guid.NewGuid();
         private MongoCollection<NoIdEntity> NoIdCollection;
+        private MongoCollection<CustomIdEntity> CustomIdCollection;
 
         public override void SetupFixture()
         {
@@ -88,6 +89,9 @@ namespace FluentMongo.Linq
             NoIdCollection = GetCollection<NoIdEntity>("no_id");
 
             NoIdCollection.Insert(new NoIdEntity { Name = "Bob" });
+
+            CustomIdCollection = GetCollection<CustomIdEntity>("custom_id");
+            CustomIdCollection.Insert(new CustomIdEntity { Id = new CustomId { FirstName = "John", LastName = "Doe" } });
         }
 
         [Test]
@@ -555,6 +559,24 @@ namespace FluentMongo.Linq
             var noIdName = NoIdCollection.AsQueryable().Select(n => n.Name).First();
 
             Assert.AreEqual("Bob", noIdName);
+        }
+
+        [Test]
+        public void QueryWithCustomIdEntity()
+        {
+            var customId = CustomIdCollection.AsQueryable().Where(c => c.Id.FirstName == "John").Single();
+
+            Assert.AreEqual("John", customId.Id.FirstName);
+            Assert.AreEqual("Doe", customId.Id.LastName);
+        }
+
+        [Test]
+        public void SelectSubIdFieldsWithCustomIdEntity()
+        {
+            var customId = CustomIdCollection.AsQueryable().Select(c => new { c.Id.FirstName, c.Id.LastName }).Single();
+
+            Assert.AreEqual("John", customId.FirstName);
+            Assert.AreEqual("Doe", customId.LastName);
         }
     }
 }

--- a/src/FluentMongo/Linq/Translators/MongoQueryObjectBuilder.cs
+++ b/src/FluentMongo/Linq/Translators/MongoQueryObjectBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentMongo.Linq.Expressions;
 using System.Linq.Expressions;
+using System.Linq;
 
 namespace FluentMongo.Linq.Translators
 {
@@ -57,7 +58,7 @@ namespace FluentMongo.Linq.Translators
                 }
 
                 // if the _id field isn't selected, then unselect it explicitly
-                if (!_queryObject.Fields.Contains("_id"))
+                if (!_queryObject.Fields.Any(e => e.Name.StartsWith("_id")))
                     _queryObject.Fields.Add("_id", 0);
             }
 


### PR DESCRIPTION
When selecting sub-id elements, the _id elements mustn't be de-selected from the Fields clause.
This fix check if any field StartsWith _id instead of equal to _id.
