### PR TITLE
Fixes behaviour of OfType for class hierarchies where the root class is ...

### DIFF
--- a/src/FluentMongo.Tests/Linq/Entities.cs
+++ b/src/FluentMongo.Tests/Linq/Entities.cs
@@ -103,4 +103,22 @@ namespace FluentMongo.Linq
     {
         public CustomId Id { get; set; }
     }
+
+    [BsonDiscriminator(RootClass = true)]
+    public class RootClass
+    {
+        public ObjectId Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    public class MiddleClass : RootClass
+    {
+        
+    }
+
+    public class InheritedClass : MiddleClass
+    {
+        
+    }
 }

--- a/src/FluentMongo.Tests/Linq/MongoQueryOfTypeTests.cs
+++ b/src/FluentMongo.Tests/Linq/MongoQueryOfTypeTests.cs
@@ -10,6 +10,8 @@ namespace FluentMongo.Linq
     [TestFixture]
     public class MongoQueryOfTypeTests : LinqTestBase
     {
+        protected MongoCollection<RootClass> DiscriminatedCollection;
+
         public override void SetupFixture()
         {
             base.SetupFixture();
@@ -45,6 +47,12 @@ namespace FluentMongo.Linq
                 Salary = 50000.0,
                 Age = 42
             }, SafeMode.True);
+
+            DiscriminatedCollection = GetCollection<RootClass>("root");
+            DiscriminatedCollection.Insert(new InheritedClass
+            {
+                Name = "Tony"
+            }, SafeMode.True);
         }
 
         [Test]
@@ -73,6 +81,14 @@ namespace FluentMongo.Linq
 
             Assert.AreEqual(1, people.Count);
             Assert.AreEqual("Sonny", people.First().FirstName);
+        }
+
+        [Test]
+        public void OfTypeWithHierarchicalDiscriminator()
+        {
+            var items = DiscriminatedCollection.AsQueryable().OfType<MiddleClass>().ToList();
+
+            Assert.AreEqual(1, items.Count);
         }
     }
 }

--- a/src/FluentMongo/Linq/QueryFormatters/BsonElementsFormatter.cs
+++ b/src/FluentMongo/Linq/QueryFormatters/BsonElementsFormatter.cs
@@ -243,8 +243,19 @@ namespace FluentMongo.Linq.QueryFormatters
             var convention = BsonDefaultSerializer.LookupDiscriminatorConvention(b.TypeOperand);
             var discriminator = convention.GetDiscriminator(b.Expression.Type, b.TypeOperand);
 
-            PushElementName(convention.ElementName);
-            AddElementWithValue(discriminator);
+            if (discriminator.IsBsonArray)
+            {
+                PushElementName("$and");
+                var values = discriminator.AsBsonArray
+                    .Select(v => new BsonDocument(new BsonElement(convention.ElementName, v)))
+                    .ToList();
+                AddElementWithValue(new BsonArray(values));
+            }
+            else
+            {
+                PushElementName(convention.ElementName);
+                AddElementWithValue(discriminator);
+            }
 
             return b;
         }


### PR DESCRIPTION
...decorated with [BsonDiscriminator(RootClass = true)]. When this attribute is set, OfType now finds documents of the specific type, as well as derived types. This mimics the standard behaviour of OfType.
