### PR TITLE
allow users to change collection attribute name using DataMemberAttribut...

### DIFF
--- a/src/FluentMongo/FluentMongo.csproj
+++ b/src/FluentMongo/FluentMongo.csproj
@@ -42,6 +42,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/src/FluentMongo/Linq/Translators/FieldBinder.cs
+++ b/src/FluentMongo/Linq/Translators/FieldBinder.cs
@@ -139,7 +139,8 @@ namespace FluentMongo.Linq.Translators
                     Expression e;
                     if (_determiner.IsGroupingKey(m))
                     {
-                        _fieldParts.Push(m.Member.Name);
+                        var name = m.Member.ResolveName();
+                        _fieldParts.Push(name);
                         Visit(m.Expression);
                         return m;
                     }
@@ -157,7 +158,7 @@ namespace FluentMongo.Linq.Translators
                     else if(e == null)
                     {
                         var classMap = BsonClassMap.LookupClassMap(declaringType);
-                        var propMap = classMap.GetMemberMap(m.Member.Name);
+                        var propMap = classMap.GetMemberMap(m.Member.ResolveName());
                         if (propMap != null)
                         {
                             _fieldParts.Push(propMap.ElementName);
@@ -166,7 +167,7 @@ namespace FluentMongo.Linq.Translators
                                 _bsonMemberMap = propMap;
                         }
                         else
-                            _fieldParts.Push(m.Member.Name);
+                            _fieldParts.Push(m.Member.ResolveName());
 
                         Visit(m.Expression);
                         return m;

--- a/src/FluentMongo/Linq/Util/ReflectionExtensions.cs
+++ b/src/FluentMongo/Linq/Util/ReflectionExtensions.cs
@@ -4,6 +4,8 @@ using System.Linq;
 
 namespace FluentMongo.Linq
 {
+    using System.Runtime.Serialization;
+
     /// <summary>
     /// 
     /// </summary>
@@ -108,6 +110,22 @@ namespace FluentMongo.Linq
                 throw new ArgumentException("Must be an open generic type.", "openType");
 
             return type.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == openType);
+        }
+
+        public static string ResolveName(this MemberInfo member)
+        {
+            string name = null;
+            var dataMemberAttribute = member.GetCustomAttribute<DataMemberAttribute>(true);
+
+            if (dataMemberAttribute != null)
+            {
+                name = dataMemberAttribute.Name;
+            }
+            if (string.IsNullOrEmpty(name))
+            {
+                name = member.Name;
+            }
+            return name;
         }
     }
 }


### PR DESCRIPTION
Hi,
I've made a change which allow the query provider to use custom property name on my objects.

My use case is to allow the fs.files query using a strongly typed class with Properties containing proper naming convencion.

I've tried to integrate those changes in the test project but I was unable to define where to put those changes to test.
Can you guide me o provide a test case to those changes I made?
